### PR TITLE
refactor: formation of zod to fastify schemas

### DIFF
--- a/.github/workflows/two_weeks_log_clearing.yml
+++ b/.github/workflows/two_weeks_log_clearing.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Hit the clear logs endpoint
         run: |
           curl --url '${{ secrets.APP_CLEAR_LOGS_ENDPOINT }}' \
-          --header 'X-APP-CLIENT-ID: ${{ secrets.APP_CLEAR_LOGS_CLIENT_ID }}'
+          --header 'X-APP-SERVICE-ID: ${{ secrets.APP_CLEAR_LOGS_CLIENT_ID }}'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-logging-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "private": true,
   "main": "dist/index.js",

--- a/src/components/common.schema.ts
+++ b/src/components/common.schema.ts
@@ -5,13 +5,13 @@ const SuccessResponseSchema = z.object({
   message: z.string().optional(),
 });
 
-const XAppClientIdHeaderSchema = z.object({
-  "x-app-client-id": z.string(),
+const XAppServiceIdHeaderSchema = z.object({
+  "x-app-service-id": z.string(),
 });
 
-export type TXAppClientIdHeaderSchema = z.infer<typeof XAppClientIdHeaderSchema>;
+export type TXAppServiceIdHeaderSchema = z.infer<typeof XAppServiceIdHeaderSchema>;
 
 export const commonModels = {
-  XAppClientIdHeader: XAppClientIdHeaderSchema,
+  XAppServiceIdHeader: XAppServiceIdHeaderSchema,
   SuccessResponse: SuccessResponseSchema,
 };

--- a/src/components/common.schema.ts
+++ b/src/components/common.schema.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { buildJsonSchemas } from "fastify-zod";
 
 const SuccessResponseSchema = z.object({
   success: z.boolean(),
@@ -12,12 +11,7 @@ const XAppClientIdHeaderSchema = z.object({
 
 export type TXAppClientIdHeaderSchema = z.infer<typeof XAppClientIdHeaderSchema>;
 
-export const { schemas: commonSchemas, $ref } = buildJsonSchemas(
-  {
-    SuccessResponseSchema,
-    XAppClientIdHeaderSchema,
-  },
-  {
-    $id: "Common",
-  }
-);
+export const commonModels = {
+  XAppClientIdHeader: XAppClientIdHeaderSchema,
+  SuccessResponse: SuccessResponseSchema,
+};

--- a/src/components/logging/logging.routes.ts
+++ b/src/components/logging/logging.routes.ts
@@ -11,7 +11,7 @@ export async function logRoutes(server: FastifyInstance) {
         tags: ["Logs"],
         operationId: `CleanLogsForAll`,
         description: "Clean all logs for all services that are not persisted",
-        headers: $ref("XAppClientIdHeader"),
+        headers: $ref("XAppServiceIdHeader"),
         response: {
           200: $ref("SuccessResponse"),
           403: $ref("SuccessResponse"),

--- a/src/components/logging/logging.routes.ts
+++ b/src/components/logging/logging.routes.ts
@@ -1,22 +1,21 @@
 import { FastifyInstance } from "fastify";
 
-import { $ref as $refCommon } from "../common.schema";
-
+import { $ref } from "../../config/fastify-zod";
 import { cleanLogsForAllHandler } from "./logging.controller";
 
 export async function logRoutes(server: FastifyInstance) {
   server.get(
-    "/clean",
+    `/clean`,
     {
       schema: {
         tags: ["Logs"],
-        operationId: "CleanLogsForAll",
+        operationId: `CleanLogsForAll`,
         description: "Clean all logs for all services that are not persisted",
-        headers: $refCommon("XAppClientIdHeaderSchema"),
+        headers: $ref("XAppClientIdHeader"),
         response: {
-          200: $refCommon("SuccessResponseSchema"),
-          403: $refCommon("SuccessResponseSchema"), //error
-          500: $refCommon("SuccessResponseSchema"), //error
+          200: $ref("SuccessResponse"),
+          403: $ref("SuccessResponse"),
+          500: $ref("SuccessResponse"),
         },
       },
     },

--- a/src/components/logging/logging.schema.ts
+++ b/src/components/logging/logging.schema.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { buildJsonSchemas } from "fastify-zod";
 
 const logCreateInput = {
   action: z.string(),
@@ -28,13 +27,8 @@ const LogsResponseSchema = z.array(LogResponseSchema);
 
 export type CreateLogInput = z.infer<typeof CreateLogInputSchema>;
 
-export const { schemas: logSchemas, $ref } = buildJsonSchemas(
-  {
-    CreateLogInputSchema,
-    LogResponseSchema,
-    LogsResponseSchema,
-  },
-  {
-    $id: "Logs",
-  }
-);
+export const logModels = {
+  CreateLogDTO: CreateLogInputSchema,
+  LogResponse: LogResponseSchema,
+  LogListResponse: LogsResponseSchema,
+};

--- a/src/components/logging/logging.service.ts
+++ b/src/components/logging/logging.service.ts
@@ -1,4 +1,3 @@
-import { env } from "../../config/env";
 import { prisma } from "../../config/prisma";
 import { CreateLogInput } from "./logging.schema";
 
@@ -35,10 +34,7 @@ export async function getLogs({
  *
  * Currently, the number of months is defined in the env file
  */
-export async function cleanLogsForAll() {
-  const numberOfMonthsToRemove = Number(env.DEFAULT_NUM_OF_MONTHS_TO_DELETE);
-  // console.log("number of months to remove", numberOfMonthsToRemove);
-
+export async function cleanLogsForAll({ numberOfMonthsToRemove }: { numberOfMonthsToRemove: number }) {
   const date = new Date();
   date.setMonth(date.getMonth() - numberOfMonthsToRemove);
 

--- a/src/components/services/services.routes.ts
+++ b/src/components/services/services.routes.ts
@@ -1,7 +1,6 @@
 import { FastifyInstance } from "fastify";
 
-import { $ref as $refService } from "./services.schema";
-import { $ref as $refLog } from "../logging/logging.schema";
+import { $ref } from "../../config/fastify-zod";
 import { createServiceLogHandler, getServiceLogsHandler } from "./services.controller";
 
 export async function serviceRoutes(server: FastifyInstance) {
@@ -11,10 +10,10 @@ export async function serviceRoutes(server: FastifyInstance) {
       schema: {
         tags: ["Services"],
         operationId: "GetLogsForService",
-        params: $refService("ServiceIdRouteParamSchema"),
-        querystring: $refService("GetServiceLogsQueryParamsSchema"),
+        params: $ref("ServiceIdParameter"),
+        querystring: $ref("ServiceLogListQueryParams"),
         response: {
-          200: $refLog("LogsResponseSchema"),
+          200: $ref("LogListResponse"),
         },
       },
     },
@@ -26,10 +25,10 @@ export async function serviceRoutes(server: FastifyInstance) {
       schema: {
         tags: ["Services"],
         operationId: "CreateLogForService",
-        body: $refLog("CreateLogInputSchema"),
-        params: $refService("ServiceIdRouteParamSchema"),
+        body: $ref("CreateLogDTO"),
+        params: $ref("ServiceIdParameter"),
         response: {
-          201: $refLog("LogResponseSchema"),
+          201: $ref("LogResponse"),
         },
       },
     },

--- a/src/components/services/services.schema.ts
+++ b/src/components/services/services.schema.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { buildJsonSchemas } from "fastify-zod";
 
 const ServiceIdRouteParamSchema = z.object({
   ServiceId: z.string(),
@@ -15,12 +14,7 @@ const GetServiceLogsQueryParamsSchema = z.object({
 export type ServiceIdRouteParamInput = z.infer<typeof ServiceIdRouteParamSchema>;
 export type GetServiceLogsQueryParamsInput = z.infer<typeof GetServiceLogsQueryParamsSchema>;
 
-export const { schemas: serviceSchemas, $ref } = buildJsonSchemas(
-  {
-    ServiceIdRouteParamSchema,
-    GetServiceLogsQueryParamsSchema,
-  },
-  {
-    $id: "Services",
-  }
-);
+export const serviceModels = {
+  ServiceIdParameter: ServiceIdRouteParamSchema,
+  ServiceLogListQueryParams: GetServiceLogsQueryParamsSchema,
+};

--- a/src/config/fastify-zod.ts
+++ b/src/config/fastify-zod.ts
@@ -1,0 +1,11 @@
+import { buildJsonSchemas } from "fastify-zod";
+
+import { commonModels } from "../components/common.schema";
+import { logModels } from "../components/logging/logging.schema";
+import { serviceModels } from "../components/services/services.schema";
+
+export const zodModels = { ...commonModels, ...logModels, ...serviceModels };
+const build = buildJsonSchemas(zodModels);
+
+export const { schemas, $ref } = build;
+export default build;

--- a/src/fastify.d.ts
+++ b/src/fastify.d.ts
@@ -1,0 +1,8 @@
+import type { FastifyZod } from "fastify-zod";
+import { zodModels } from "./config/fastify-zod";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    readonly zod: FastifyZod<typeof zodModels>;
+  }
+}


### PR DESCRIPTION
* Refactored how the zod schemas and piped into fastify.
* Flushed out the swagger description regarding the API usage.
* Redirect `/` to `/docs`.
* Redirect `/swagger` to `/docs`.
* Usage of header `x-app-client-id` renamed to `x-app-service-id` for consistency.
* Removed unused `zod-to-json-schema` package.